### PR TITLE
Merge sfrinaldi/add-ci-check into develop

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-bug.yml
+++ b/.github/ISSUE_TEMPLATE/02-bug.yml
@@ -1,0 +1,43 @@
+name: "Bug Report"
+description: "Issue for reporting a bug that needs fixing for the repository."
+title: "[bug]: "
+labels: ["bug"]
+body:
+- type: checkboxes
+  attributes: 
+    label: "Does a similar issue / bug report exist already?"
+    description: Verify a similar issue does not already exist within this repository for this bug.
+    options:
+    - label: "No"
+      required: true
+- type: textarea
+  attributes:
+    label: "Bug Behavior"
+    description: "Describe the issue / bug that you are experiencing and what it impacts."
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: "Expected Behavior"
+    description: "Detail what is expected to happen instead / intended behavior."
+  validations:
+    required: false
+- type: checkboxes
+  attributes:
+    label: "Local build or CI process?"
+    description: "Is this issue with local build or CI workflow?"
+    options:
+    - label: "CI Workflow"
+    - label: "Local Build"
+    - label: "Other"
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: "Additional Info"
+    description: |
+      Add any links, references, and screenshots that might help as well as any additional information that this template did not cover.
+      
+      Tip: Files can be attached by clicking this area to highlight it and then drag / drop.
+  validations:
+    required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+# Description
+_Add a brief description of what this Pull Request encompasses._
+
+## Changes Made
+_List bullet points of what changes were done._
+
+## Related Issues
+_List any issues this Pull Request relates too in order to tie issues with Pull Requests._
+
+## Testing Performed
+_List any related testing that was preformed or direct to an issue that has this information. Remove this section as needed._
+
+### ETC Branch
+_Indicate what branch the pipeline checks should be using for running tests against (if applicable)._
+
+> [!Note]
+> You will have to request someone to change the variable for this repository to the correct branch that you indicated above for the pipeline to run accordingly! (Defaults to main branch for the corresponding ETC repo)
+
+---------------------
+
+**NOTE:** Refer to the [UASAL Development Guide](https://teledocs.space/docs/stp202502_0006) for the PR checklist for guidance as well as other general PR information._
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,12 @@
 # NOTE: Change / update the BRANCH variable in the repository settings to test against specific branches
 # (Or indicate in the PR for someone to do that for you)
 
-name: CI Pipeline
+name: Package Install & PyTest Checks
 
 on:
-  push:
-    branches:
-      - '**'
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
 jobs:
   check-tomls-python3-12:
     runs-on: ubuntu-latest
@@ -24,12 +24,15 @@ jobs:
       run: |
         python -m pip install --upgrade pip
 
+      # Checkout / clone stp_etc_imaging (custom branch) 
     - name: Checkout ETC Package
       uses: actions/checkout@v4
     - name: Checkout ETC WCC
       run: | 
         git clone --branch "${{ vars.BRANCH }}" https://github.com/uasal/stp_etc_imaging.git
 
+      # Install the custom branch stp_etc_imaging package  
+      # Re-installs the config repo to be the one checkout
     - name: Install Packages
       run: |
         cd stp_etc_imaging
@@ -37,6 +40,7 @@ jobs:
         cd ..
         pip install .[dev]
 
+      # Pytest Run for the configuration package
     - name: Run PyTests- Config Package
       id: config_pytest_results
       run: |
@@ -45,8 +49,9 @@ jobs:
 
         PASSED=$(python -c "import re; f=open('config_pytest_output.txt').read(); match=re.search(r'(\d+) passed', f); print(match.group(1) if match else '0')")
         FAILED=$(grep -oP '\d+(?= failed)' config_pytest_output.txt || echo "0")
-
-    - name: Run PyTests- ETC Package Custom Branch
+      
+    # Pytest from stp_etc_imaging Package (custom branch)
+    - name: Run PyTests- stp_etc_imaging branch
       id: etc_pytest_results
       run: |
         cd stp_etc_imaging/tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/checkout@v4
     - name: Checkout ETC WCC
       run: | 
-        git clone https://github.com/uasal/stp_etc_imaging.git
+        git clone --branch $BRANCH https://github.com/uasal/stp_etc_imaging.git
 
     - name: Install Packages
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,6 @@
+# NOTE: Change / update the BRANCH variable in the repository settings to test against specific branches
+# (Or indicate in the PR for someone to do that for you)
+
 name: CI Pipeline
 
 on:
@@ -25,7 +28,7 @@ jobs:
       uses: actions/checkout@v4
     - name: Checkout ETC WCC
       run: | 
-        git clone --branch $BRANCH https://github.com/uasal/stp_etc_imaging.git
+        git clone --branch "${{ vars.BRANCH }}" https://github.com/uasal/stp_etc_imaging.git
 
     - name: Install Packages
       run: |
@@ -43,7 +46,7 @@ jobs:
         PASSED=$(python -c "import re; f=open('config_pytest_output.txt').read(); match=re.search(r'(\d+) passed', f); print(match.group(1) if match else '0')")
         FAILED=$(grep -oP '\d+(?= failed)' config_pytest_output.txt || echo "0")
 
-    - name: Run PyTests- ETC Package
+    - name: Run PyTests- ETC Package Custom Branch
       id: etc_pytest_results
       run: |
         cd stp_etc_imaging/tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,53 @@
+name: CI Pipeline
+
+on:
+  push:
+    branches:
+      - '**'
+jobs:
+  check-tomls-python3-12:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+
+    - name: Checkout ETC Package
+      uses: actions/checkout@v4
+    - name: Checkout ETC WCC
+      run: | 
+        git clone https://github.com/uasal/stp_etc_imaging.git
+
+    - name: Install Packages
+      run: |
+        cd stp_etc_imaging
+        pip install .[dev]
+        cd ..
+        pip install .[dev]
+
+    - name: Run PyTests- Config Package
+      id: config_pytest_results
+      run: |
+        cd tests
+        pytest --tb=short --maxfail=1 --junitxml=report.xml | tee config_pytest_output.txt
+
+        PASSED=$(python -c "import re; f=open('config_pytest_output.txt').read(); match=re.search(r'(\d+) passed', f); print(match.group(1) if match else '0')")
+        FAILED=$(grep -oP '\d+(?= failed)' config_pytest_output.txt || echo "0")
+
+    - name: Run PyTests- ETC Package
+      id: etc_pytest_results
+      run: |
+        cd stp_etc_imaging/tests
+        pytest --tb=short --maxfail=1 --junitxml=report.xml | tee etc_pytest_output.txt
+
+        PASSED=$(python -c "import re; f=open('etc_pytest_output.txt').read(); match=re.search(r'(\d+) passed', f); print(match.group(1) if match else '0')")
+        FAILED=$(grep -oP '\d+(?= failed)' etc_pytest_output.txt || echo "0")

--- a/README.md
+++ b/README.md
@@ -2,15 +2,16 @@
 
 Space Telescope Pathfinder's WCC-specific repository for support data and configuration management as an installable python package 
 
-Details on the change control process are found in the [coronograph design documentation repository](https://github.com/uasal/spacecoron_design_docs)
+Details on the Configuration Management Plan for these repos can be found in the [UASAL Development Guide](https://uasal.github.io/uasal_development_guide/python/configuration_management.html).
 
 The parameters for each subsystem are found in the `configs` directory, and supporting data is found in the `support_data` directory.
 A description of how configurations are used in UASAL software, users can find an example notebook in the `docs` directory of the  [config_project_template](https://github.com/uasal/config_project_template) repository. 
+
 ## Dependencies and Requirements
 
-config_stp_wcc is dependent on [utils_config](https://github.com/uasal/utils_config) but will automatically be installed via 
+`config_stp_wcc` is dependent on [utils_config](https://github.com/uasal/utils_config) but will automatically be installed via 
 ```sh 
-pip install "git+https://github.com/uasal/utils_config.git@develop"
+pip install git+https://github.com/uasal/config_stp_wcc.git
 ```
 
 ssh keys are necessary for the pip-based install. Verify you have ssh keys installed in GitHub, or check out this [ssh key tutorial](https://github.com/uasal/lab_documents/blob/main/ssh_key_tutorial.md)
@@ -18,14 +19,14 @@ ssh keys are necessary for the pip-based install. Verify you have ssh keys insta
 ## Pip Installation
 
 ```sh
-pip install git+ssh://git@github.com/uasal/config_stp_wcc.git
+pip install git+https://github.com/uasal/config_stp_wcc.git
 ```
 
 ## Git Clone Installation
 
 ### **1. Clone the Repository**
 ```sh
-git clone git@github.com:uasal/config_stp_wcc.git
+git clone https://github.com/uasal/config_stp_wcc.git
 cd config_stp_wcc
 ```
 
@@ -36,7 +37,7 @@ pip install .
 
 ## Usage
 
-config_stp_wcc makes usage of the ConfigLoader class (as *config_loader*) from utils_config via the `load_config_values` method, accepting 'raw' 'parsed' or 'unitless' as an argument, returning a dictionary after parsing the 'configs' directory for .toml filies
+`config_stp_wcc` makes usage of the ConfigLoader class (as *config_loader*) from utils_config via the `load_config_values` method, accepting 'raw' 'parsed' or 'unitless' as an argument, returning a dictionary after parsing the 'configs' directory for .toml files
 ```python
 import config_stp_wcc
 data = config_stp_wcc.load_config_values()
@@ -56,7 +57,7 @@ print(data_path)
 
 ## Astropy Unit Validation
 
-All .toml config values should have a valid astropy unit if any units are defined. If no unit is included, the value is assumed to be unitless. A GitHub CI will automatically run a test on push to validate astropy units in the configs, reporting any issues with non-conforming astropy units. If you'd like to perform validation locally, you may run `pytest tests/test_configs.py` from the root directory of the repo. Alternatively in your python environment you may run the following snippit:
+All .toml config values should have a valid astropy unit if any units are defined. If no unit is included, the value is assumed to be unitless. A GitHub CI will automatically run a test on push to validate astropy units in the configs, reporting any issues with non-conforming astropy units. If you'd like to perform validation locally, you may run `pytest tests/test_configs.py` from the root directory of the repo. Alternatively in your python environment you may run the following snippet:
 ```python
 import config_stp_wcc
 config_stp_wcc.load_config_values("parsed", return_loader=True).validate_astropy()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-toml
-utils_config


### PR DESCRIPTION
# Description
Updating templates and CI process for allowing to test against other branches and with the ETC package at least. Slightly manual but don't need to update the ci file physically to do this at least (change `BRANCH` variable in repo settings).

## Changes Made
- Update PR Template
  - Include branch indicator for what ETC version you want to test against
  - Want to do this a bit differently in the future but just implemented this quickly for testing purposes
- Update `ci.yaml`
  - Clones the '[stp_etc_imaging](https://github.com/uasal/stp_etc_imaging)' package for testing against and installs
    - Uses `BRANCH` variable for allowing testing against specific branches for the package
      - Probably would want to have a tag / release for this process as well in the future but again implemented this quickly  
  - Remove `requirement.txt` dependency step 
- Removed `requirements.txt`
  - Utilizing the dev install for ci instead (no need for both now)      
- Update `README.md`
  - Small corrections / fixes with repos being public
  - Config information pointing to UASAL Development Guide instead now 

## Related Issues
- https://github.com/uasal/config_stp_wcc/issues/22

Closes #22

## Testing Performed
Used with testing PR: https://github.com/uasal/config_stp_wcc/pull/21

> [!Note]
> Need to update the `BRANCH` variable in the repo settings for selecting what package of ETC you want to use for the testing currently. Variable _should_ be manually changed back to `develop` afterwards (for now at least).